### PR TITLE
Improve swift-syntax version compatibility

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,7 @@ let package = Package(
     ),
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-syntax.git", from: "600.0.0")
+    .package(url: "https://github.com/apple/swift-syntax.git", "600.0.0"..<"603.0.0")
   ],
   targets: [
     .target(


### PR DESCRIPTION
## Description

Improves compatibility with other swift-syntax dependent libraries by specifying a version range.

## Changes

- Update swift-syntax dependency from open-ended from: "600.0.0" to explicit range "600.0.0"..<"603.0.0"
- Allow using the highest possible swift-syntax version (602.0.0)
- Reduce dependency resolution conflicts with other packages

## Reference

[Being a Good Citizen in the Land of SwiftSyntax - Point-Free](https://www.pointfree.co/blog/posts/116-being-a-good-citizen-in-the-land-of-swiftsyntax)