### PR TITLE
Fix typo in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ class MyCellView: UIView {
 
   var body: Layout {
     HStack {
-      VStack(alignment: leading) {
+      VStack(alignment: .leading) {
         titleLabel
         Spacer(4)
         subtitleLabel


### PR DESCRIPTION
The original code used a `leading` symbol that doesn't exist. The right one is `.leading`.